### PR TITLE
Add SEO metadata and analytics to app pages

### DIFF
--- a/apps/Animation-Effects.html
+++ b/apps/Animation-Effects.html
@@ -24,7 +24,7 @@
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->
-  <link rel="icon" href="images/favicon.jpg" type="image/jpeg">
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>

--- a/apps/CSS-Gradient-Generator.html
+++ b/apps/CSS-Gradient-Generator.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CSS Gradient Generator</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
   
   <style>

--- a/apps/Mobile-Checker.php
+++ b/apps/Mobile-Checker.php
@@ -413,6 +413,37 @@ function analyzeDeviceCompatibility($html, $css, $dimensions) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mobile Friendliness Checker</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>

--- a/apps/Readability-Analyzer.html
+++ b/apps/Readability-Analyzer.html
@@ -3,6 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <title>Readability Analyzer</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
@@ -370,17 +401,6 @@
       }
     }
   </style>
-	
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
   <div class="container">

--- a/apps/Website-Migration-Planner.html
+++ b/apps/Website-Migration-Planner.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Website Migration Planner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
   <style>

--- a/apps/Zen-Bubbles.html
+++ b/apps/Zen-Bubbles.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Zen Bubbles</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
 
   <!-- SEO Meta Tags -->
   <meta name="description" content="Zen Bubbles is a relaxing browser game where you pop floating pastel bubbles under a starry sky. Soothing, simple, and satisfying.">

--- a/apps/accessibility-comprehensive.php
+++ b/apps/accessibility-comprehensive.php
@@ -961,6 +961,37 @@ if (!empty($scanResults)) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Comprehensive Accessibility Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <style>
         * {
             margin: 0;

--- a/apps/accessibility-lite.php
+++ b/apps/accessibility-lite.php
@@ -384,6 +384,37 @@ if (!empty($scanResults)) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Accessibility Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <style>
         * {
             margin: 0;

--- a/apps/card-component-generator.html
+++ b/apps/card-component-generator.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Card Builder Pro</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <style>
     * {
       box-sizing: border-box;

--- a/apps/cropper.html
+++ b/apps/cropper.html
@@ -12,6 +12,37 @@
 
   <meta charset="UTF-8">
   <title>Advanced Image Editor</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <!-- Include Cropper.js CSS -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css">
   <style>

--- a/apps/csv-parse-8.php
+++ b/apps/csv-parse-8.php
@@ -17,6 +17,37 @@
 <head>
   <meta charset="UTF-8" />
   <title>Advanced CSV Filtering Tool (Full-Width Expand)</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <!-- Bootstrap CSS for improved styling -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
 
@@ -57,16 +88,6 @@
       cursor: pointer;
     }
   </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
   <div class="container">

--- a/apps/email-confirmation-14.php
+++ b/apps/email-confirmation-14.php
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Professional Email Builder</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
 
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/apps/flexbox-generator-2.html
+++ b/apps/flexbox-generator-2.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Flexbox CSS Generator</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;800&display=swap" rel="stylesheet">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
   <style>

--- a/apps/flexbox-generator.html
+++ b/apps/flexbox-generator.html
@@ -4,6 +4,37 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flexbox CSS Generator</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <style>
         /* reset & layout */

--- a/apps/form-builder-7.html
+++ b/apps/form-builder-7.html
@@ -3,6 +3,37 @@
 <head>
   <meta charset="UTF-8" />
   <title>Accessible Drag & Drop Form Builder</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
 
   <!-- Bootstrap 5 CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />

--- a/apps/heic.html
+++ b/apps/heic.html
@@ -4,6 +4,37 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HEIC to JPG Converter - High Quality Image Conversion</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <style>
         * {
             margin: 0;

--- a/apps/ipsumchecker.php
+++ b/apps/ipsumchecker.php
@@ -90,6 +90,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lorem Ipsum Checker</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -492,16 +523,6 @@ tbody tr:nth-child(even) {
 }
 
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/keyword.php
+++ b/apps/keyword.php
@@ -3,6 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <title>Keyword Density Analyzer</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
@@ -364,15 +395,6 @@
       }
     }
   </style>
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
   <div class="container">

--- a/apps/meta-generator.php
+++ b/apps/meta-generator.php
@@ -3,6 +3,37 @@
 <head>
   <meta charset='UTF-8'>
   <title>Meta Tag Generator from URL</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
   <style>

--- a/apps/missing-alt-finder.php
+++ b/apps/missing-alt-finder.php
@@ -319,6 +319,37 @@ class AltTagScanner {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Website Alt Tag Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <style>
         * {
             margin: 0;

--- a/apps/mwformfinder.php
+++ b/apps/mwformfinder.php
@@ -108,6 +108,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Form Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -458,15 +489,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwimagescan-1.php
+++ b/apps/mwimagescan-1.php
@@ -293,6 +293,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Image Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -739,16 +770,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwimagescan.php
+++ b/apps/mwimagescan.php
@@ -230,6 +230,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Image Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -666,16 +697,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwperformanceaudit-2.php
+++ b/apps/mwperformanceaudit-2.php
@@ -346,6 +346,37 @@ function formatBytes($size, $precision = 2) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Performance Auditor</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -803,16 +834,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwperformanceaudit.php
+++ b/apps/mwperformanceaudit.php
@@ -346,6 +346,37 @@ function formatBytes($size, $precision = 2) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Performance Auditor</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -785,16 +816,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwsecurityscanner.php
+++ b/apps/mwsecurityscanner.php
@@ -351,6 +351,37 @@ function getRiskLevel($filename) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Security Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -826,16 +857,6 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/mwtemplatescan5.php
+++ b/apps/mwtemplatescan5.php
@@ -100,6 +100,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MW Template Scanner</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
@@ -502,16 +533,6 @@ tbody tr:nth-child(even) {
 }
 
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/onborading-2.html
+++ b/apps/onborading-2.html
@@ -4,6 +4,37 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Morweb CMS – Enhanced Onboarding</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <style>
     :root {
       --bg: #0f1216;

--- a/apps/seo4.php
+++ b/apps/seo4.php
@@ -217,6 +217,37 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>SEO Sitemap Audit</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
   <style>
@@ -560,15 +591,6 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       }
     }
   </style>
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
   <div class="container">

--- a/apps/seo5.php
+++ b/apps/seo5.php
@@ -217,6 +217,37 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>SEO Sitemap Audit</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
   <style>
@@ -560,15 +591,6 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       }
     }
   </style>
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
   <div class="container">

--- a/apps/sitemap_exporter.php
+++ b/apps/sitemap_exporter.php
@@ -144,6 +144,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sitemap to CSV Exporter</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
     * {
@@ -359,16 +390,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         display: block;
     }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">

--- a/apps/sitemap_exporter_2.php
+++ b/apps/sitemap_exporter_2.php
@@ -156,6 +156,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sitemap to CSV Exporter</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
     * {
@@ -484,15 +515,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     </style>
-	
-	<!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-1RGGXKCNB6');
-    </script>
 </head>
 <body>
     <div class="container">

--- a/apps/sitemap_exporter_3.php
+++ b/apps/sitemap_exporter_3.php
@@ -156,6 +156,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sitemap to CSV Exporter</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
     * {
@@ -484,15 +515,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     </style>
-	
-	<!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-1RGGXKCNB6');
-    </script>
 </head>
 <body>
     <div class="container">

--- a/apps/sitemap_exporter_content.php
+++ b/apps/sitemap_exporter_content.php
@@ -170,6 +170,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sitemap Content Exporter</title>
+  <!-- SEO Meta Tags -->
+  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
+  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="author" content="Brent">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
+  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
+  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+
+  <!-- Favicon -->
+  <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-1RGGXKCNB6');
+  </script>
+
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
     /* (existing CSS remains unchanged) */
@@ -375,16 +406,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         font-size: 1.2rem;
     }
     </style>
-	
-	<!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-1RGGXKCNB6"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-1RGGXKCNB6');
-  </script>
-	
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- add consistent SEO metadata, social sharing tags, and favicon links to every page in `apps`
- embed the shared Google Analytics tracking snippet across the app pages

## Testing
- not run (static changes)


------
https://chatgpt.com/codex/tasks/task_e_68e31b6102808331a47e676a9375ebe3