### PR TITLE
Customize metadata for each app page

### DIFF
--- a/apps/accessibility-audit-suite.php
+++ b/apps/accessibility-audit-suite.php
@@ -960,24 +960,24 @@ if (!empty($scanResults)) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Comprehensive Accessibility Scanner</title>
+    <title>Comprehensive Accessibility Scanner – WCAG Audit Suite</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Conduct deep accessibility audits, track WCAG violations, and export compliance reports with the BREN7 Comprehensive Accessibility Scanner.">
+  <meta name="keywords" content="accessibility audit suite, wcag compliance tool, accessibility dashboard, violation tracker, Morweb accessibility">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Comprehensive Accessibility Scanner – WCAG Audit Suite">
+  <meta property="og:description" content="Monitor WCAG issues, severity levels, and remediation progress with the BREN7 Accessibility Audit Suite.">
+  <meta property="og:url" content="https://bren7.com/apps/accessibility-audit-suite.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Comprehensive Accessibility Scanner – WCAG Audit Suite">
+  <meta name="twitter:description" content="Run full accessibility audits and export reports with the BREN7 Accessibility Suite.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/accessibility-quick-scan.php
+++ b/apps/accessibility-quick-scan.php
@@ -383,24 +383,24 @@ if (!empty($scanResults)) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Accessibility Scanner</title>
+    <title>Accessibility Quick Scan – WCAG Issue Finder</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Run rapid accessibility checks across sitemap URLs and prioritize WCAG issues with the BREN7 Accessibility Quick Scan tool.">
+  <meta name="keywords" content="accessibility scanner, wcag audit, quick compliance check, web accessibility report, Morweb accessibility">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Accessibility Quick Scan – WCAG Issue Finder">
+  <meta property="og:description" content="Surface WCAG violations, compliance levels, and critical accessibility issues using BREN7's quick scan dashboard.">
+  <meta property="og:url" content="https://bren7.com/apps/accessibility-quick-scan.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Accessibility Quick Scan – WCAG Issue Finder">
+  <meta name="twitter:description" content="Quickly assess WCAG issues across pages with the BREN7 Accessibility Quick Scan tool.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/accessible-form-builder.php
+++ b/apps/accessible-form-builder.php
@@ -2,24 +2,24 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Accessible Drag & Drop Form Builder</title>
+  <title>Accessible Drag & Drop Form Builder – WCAG-Ready Forms</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Create accessible forms with drag-and-drop fields, ARIA labels, and live previews using the BREN7 Accessible Form Builder.">
+  <meta name="keywords" content="accessible form builder, drag and drop forms, wcag compliant forms, aria label generator, form accessibility tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Accessible Drag & Drop Form Builder – WCAG-Ready Forms">
+  <meta property="og:description" content="Assemble accessible form components with guidance on labels, hints, and validation using BREN7's form builder.">
+  <meta property="og:url" content="https://bren7.com/apps/accessible-form-builder.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Accessible Drag & Drop Form Builder – WCAG-Ready Forms">
+  <meta name="twitter:description" content="Build accessible forms quickly with the drag-and-drop builder from BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/advanced-csv-filter.php
+++ b/apps/advanced-csv-filter.php
@@ -16,24 +16,24 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>Advanced CSV Filtering Tool (Full-Width Expand)</title>
+  <title>Advanced CSV Filtering Tool – Multi-Condition Analyzer</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Upload spreadsheets, build complex filters, and export curated datasets with the BREN7 Advanced CSV Filtering Tool.">
+  <meta name="keywords" content="csv filter tool, spreadsheet analyzer, data filtering web app, csv export, data cleanup">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Advanced CSV Filtering Tool – Multi-Condition Analyzer">
+  <meta property="og:description" content="Create layered filters, highlight matches, and download refined CSV outputs with this advanced data tool from BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/advanced-csv-filter.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Advanced CSV Filtering Tool – Multi-Condition Analyzer">
+  <meta name="twitter:description" content="Filter and export CSV data with precision using the BREN7 Advanced CSV tool.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/advanced-image-editor.php
+++ b/apps/advanced-image-editor.php
@@ -11,24 +11,24 @@
   </script>
 
   <meta charset="UTF-8">
-  <title>Advanced Image Editor</title>
+  <title>Advanced Image Editor – Browser-Based Photo Studio</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Crop, resize, filter, and annotate images directly in your browser with the BREN7 Advanced Image Editor powered by Cropper.js.">
+  <meta name="keywords" content="advanced image editor, browser photo editor, cropper tool, image annotation, online image editing">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Advanced Image Editor – Browser-Based Photo Studio">
+  <meta property="og:description" content="Edit, crop, and enhance images in real time using the BREN7 Advanced Image Editor.">
+  <meta property="og:url" content="https://bren7.com/apps/advanced-image-editor.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Advanced Image Editor – Browser-Based Photo Studio">
+  <meta name="twitter:description" content="Adjust, crop, and filter images in-browser with the BREN7 Advanced Image Editor.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/animation-effects-gallery.php
+++ b/apps/animation-effects-gallery.php
@@ -4,23 +4,23 @@
   <!-- Primary Meta Tags -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BREN7 – Animation & Effects</title>
-  <meta name="description" content="Explore interactive web tools, mini-games, and experiments from BREN7. Try out Trakster Beat Maker, Zen Bubbles, accessibility tools, and more.">
-  <meta name="keywords" content="BREN7, web projects, beat maker, accessibility tools, game prototypes, web development, experiments, utilities">
+  <title>CSS Animation Effects Gallery – BREN7</title>
+  <meta name="description" content="Build and preview CSS animations with presets, custom keyframes, and live code export using the BREN7 Animation Effects Gallery.">
+  <meta name="keywords" content="CSS animation builder, keyframe editor, animation presets, web design tool, animation preview">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph / Facebook & LinkedIn -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse through a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="CSS Animation Effects Gallery – BREN7">
+  <meta property="og:description" content="Design and preview CSS animations with customizable timing, presets, and exportable keyframes in the BREN7 Animation Effects Gallery.">
+  <meta property="og:url" content="https://bren7.com/apps/animation-effects-gallery.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="CSS Animation Effects Gallery – BREN7">
+  <meta name="twitter:description" content="Experiment with CSS animations, adjust keyframes, and export custom effects in this interactive gallery by BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/card-builder-pro.php
+++ b/apps/card-builder-pro.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Card Builder Pro</title>
+  <title>Card Builder Pro – Interactive UI Card Designer</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Design responsive content cards with live previews, layout presets, and exportable HTML using BREN7's Card Builder Pro.">
+  <meta name="keywords" content="card builder, ui card designer, component generator, html card layout, design tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Card Builder Pro – Interactive UI Card Designer">
+  <meta property="og:description" content="Customize typography, imagery, and actions to craft pixel-perfect content cards inside Card Builder Pro by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/card-builder-pro.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Card Builder Pro – Interactive UI Card Designer">
+  <meta name="twitter:description" content="Craft and export responsive cards instantly with Card Builder Pro by BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/css-gradient-generator.php
+++ b/apps/css-gradient-generator.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CSS Gradient Generator</title>
+  <title>CSS Gradient Generator – Interactive Palette Designer</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Blend colors, customize angles, and export CSS code instantly with the BREN7 CSS Gradient Generator.">
+  <meta name="keywords" content="css gradient generator, color stop editor, gradient designer, css background tool, palette creator">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="CSS Gradient Generator – Interactive Palette Designer">
+  <meta property="og:description" content="Design linear and radial gradients, preview combinations, and copy CSS with the BREN7 generator.">
+  <meta property="og:url" content="https://bren7.com/apps/css-gradient-generator.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="CSS Gradient Generator – Interactive Palette Designer">
+  <meta name="twitter:description" content="Create beautiful gradients and copy CSS instantly with BREN7's generator.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/flexbox-generator-advanced.php
+++ b/apps/flexbox-generator-advanced.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Flexbox CSS Generator</title>
+  <title>Flexbox CSS Generator – Advanced Layout Builder</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Control complex Flexbox properties, visualize item behavior, and export CSS using the advanced generator from BREN7.">
+  <meta name="keywords" content="advanced flexbox generator, css layout playground, flex properties editor, responsive flexbox tool, layout visualizer">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Flexbox CSS Generator – Advanced Layout Builder">
+  <meta property="og:description" content="Simulate flex containers, tweak advanced options, and copy CSS instantly with BREN7's Flexbox generator.">
+  <meta property="og:url" content="https://bren7.com/apps/flexbox-generator-advanced.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Flexbox CSS Generator – Advanced Layout Builder">
+  <meta name="twitter:description" content="Preview advanced Flexbox behaviors and export CSS with BREN7's generator.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/flexbox-generator-classic.php
+++ b/apps/flexbox-generator-classic.php
@@ -3,24 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Flexbox CSS Generator</title>
+    <title>Flexbox CSS Generator – Classic Layout Builder</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Experiment with container and item settings to generate production-ready Flexbox CSS using the classic builder from BREN7.">
+  <meta name="keywords" content="flexbox generator, css layout tool, flex container settings, responsive layout builder, flexbox playground">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Flexbox CSS Generator – Classic Layout Builder">
+  <meta property="og:description" content="Adjust alignment, direction, and gaps to preview Flexbox layouts and copy CSS instantly.">
+  <meta property="og:url" content="https://bren7.com/apps/flexbox-generator-classic.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Flexbox CSS Generator – Classic Layout Builder">
+  <meta name="twitter:description" content="Fine-tune Flexbox properties and grab CSS with BREN7's classic generator.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/heic-to-jpg-converter.php
+++ b/apps/heic-to-jpg-converter.php
@@ -3,24 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HEIC to JPG Converter - High Quality Image Conversion</title>
+    <title>HEIC to JPG Converter – High Quality Image Conversion</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Convert HEIC photos to JPG or PNG instantly with adjustable quality settings using BREN7's browser-based converter.">
+  <meta name="keywords" content="heic to jpg converter, image format converter, photo compression tool, heic to png, online image converter">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="HEIC to JPG Converter – High Quality Image Conversion">
+  <meta property="og:description" content="Drag and drop HEIC files to generate shareable JPG or PNG images with custom quality controls.">
+  <meta property="og:url" content="https://bren7.com/apps/heic-to-jpg-converter.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="HEIC to JPG Converter – High Quality Image Conversion">
+  <meta name="twitter:description" content="Convert HEIC photos to web-friendly JPGs in your browser with BREN7's converter.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/keyword-density-analyzer.php
+++ b/apps/keyword-density-analyzer.php
@@ -2,24 +2,24 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Keyword Density Analyzer</title>
+  <title>Keyword Density Analyzer – SEO Content Insights</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Measure keyword frequency, discover top phrases, and balance on-page SEO with the BREN7 Keyword Density Analyzer.">
+  <meta name="keywords" content="keyword density analyzer, SEO content tool, on-page optimization, phrase frequency, copy audit">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Keyword Density Analyzer – SEO Content Insights">
+  <meta property="og:description" content="Review word counts, term frequency, and content balance using the BREN7 Keyword Density Analyzer.">
+  <meta property="og:url" content="https://bren7.com/apps/keyword-density-analyzer.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Keyword Density Analyzer – SEO Content Insights">
+  <meta name="twitter:description" content="Discover the top keywords in your copy with the BREN7 Keyword Density Analyzer.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/lorem-ipsum-scanner.php
+++ b/apps/lorem-ipsum-scanner.php
@@ -89,24 +89,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lorem Ipsum Checker</title>
+    <title>Lorem Ipsum Checker – Placeholder Text Scanner</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Scan websites or sitemaps to detect leftover lorem ipsum and placeholder copy with the BREN7 Lorem Ipsum Checker.">
+  <meta name="keywords" content="lorem ipsum checker, placeholder text scanner, content quality tool, copywriting QA, sitemap scan">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Lorem Ipsum Checker – Placeholder Text Scanner">
+  <meta property="og:description" content="Identify lorem ipsum and filler copy across URLs and sitemaps with the automated BREN7 Lorem Ipsum Checker.">
+  <meta property="og:url" content="https://bren7.com/apps/lorem-ipsum-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Lorem Ipsum Checker – Placeholder Text Scanner">
+  <meta name="twitter:description" content="Quickly surface lorem ipsum across your content with the BREN7 Lorem Ipsum Checker.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/meta-tag-generator.php
+++ b/apps/meta-tag-generator.php
@@ -2,24 +2,24 @@
 <html lang='en'>
 <head>
   <meta charset='UTF-8'>
-  <title>Meta Tag Generator from URL</title>
+  <title>Meta Tag Generator – Fetch & Build SEO Tags</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Pull titles, descriptions, and social tags from any URL and generate ready-to-use HTML metadata with the BREN7 Meta Tag Generator.">
+  <meta name="keywords" content="meta tag generator, seo metadata tool, fetch url metadata, open graph builder, head tag generator">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Meta Tag Generator – Fetch & Build SEO Tags">
+  <meta property="og:description" content="Extract and customize SEO, Open Graph, and Twitter metadata from any webpage with this BREN7 tool.">
+  <meta property="og:url" content="https://bren7.com/apps/meta-tag-generator.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Meta Tag Generator – Fetch & Build SEO Tags">
+  <meta name="twitter:description" content="Generate complete SEO and social tags from any URL using BREN7's Meta Tag Generator.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/missing-alt-scanner.php
+++ b/apps/missing-alt-scanner.php
@@ -318,24 +318,24 @@ class AltTagScanner {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Website Alt Tag Scanner</title>
+    <title>Website Alt Tag Scanner – Image Accessibility Audit</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Scan sitemap URLs to pinpoint images missing alt attributes and export accessibility reports with the BREN7 Alt Tag Scanner.">
+  <meta name="keywords" content="alt text scanner, accessibility audit, image SEO tool, sitemap accessibility, Morweb compliance">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Website Alt Tag Scanner – Image Accessibility Audit">
+  <meta property="og:description" content="Identify missing image alt attributes across your sitemap with the BREN7 Website Alt Tag Scanner.">
+  <meta property="og:url" content="https://bren7.com/apps/missing-alt-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Website Alt Tag Scanner – Image Accessibility Audit">
+  <meta name="twitter:description" content="Audit sitemap images for missing alt text using the BREN7 Alt Tag Scanner.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/mobile-friendliness-checker.php
+++ b/apps/mobile-friendliness-checker.php
@@ -412,24 +412,24 @@ function analyzeDeviceCompatibility($html, $css, $dimensions) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mobile Friendliness Checker</title>
+    <title>Mobile Friendliness Checker – Responsive Design Audit</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Analyze viewport settings, tap targets, and responsive layout issues for sitemap URLs with the BREN7 Mobile Friendliness Checker.">
+  <meta name="keywords" content="mobile friendliness checker, responsive design audit, mobile usability tool, tap target analysis, Morweb mobile audit">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Mobile Friendliness Checker – Responsive Design Audit">
+  <meta property="og:description" content="Evaluate mobile usability scores and responsive issues across sitemap URLs with this BREN7 tool.">
+  <meta property="og:url" content="https://bren7.com/apps/mobile-friendliness-checker.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Mobile Friendliness Checker – Responsive Design Audit">
+  <meta name="twitter:description" content="Review responsive issues and tap target sizes with the BREN7 Mobile Friendliness Checker.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/morweb-onboarding-experience.php
+++ b/apps/morweb-onboarding-experience.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Morweb CMS – Enhanced Onboarding</title>
+  <title>Morweb CMS – Enhanced Onboarding Experience</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Explore interactive onboarding flows, task automation, and client resources inside the Morweb CMS Enhanced Onboarding Experience prototype by BREN7.">
+  <meta name="keywords" content="Morweb onboarding, client onboarding dashboard, cms training journey, implementation planner, agency workflow">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Morweb CMS – Enhanced Onboarding Experience">
+  <meta property="og:description" content="Preview the guided onboarding portal concept for Morweb CMS featuring tasks, resources, and client insights.">
+  <meta property="og:url" content="https://bren7.com/apps/morweb-onboarding-experience.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Morweb CMS – Enhanced Onboarding Experience">
+  <meta name="twitter:description" content="Tour the Morweb CMS onboarding portal concept with guided tasks and resources by BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/professional-email-builder.php
+++ b/apps/professional-email-builder.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Professional Email Builder</title>
+  <title>Professional Email Builder – Drag & Drop Template Creator</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Compose polished marketing emails with drag-and-drop layouts, live previews, and responsive testing inside the BREN7 Professional Email Builder.">
+  <meta name="keywords" content="email builder, drag and drop email editor, marketing template creator, responsive email preview, newsletter design tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Professional Email Builder – Drag & Drop Template Creator">
+  <meta property="og:description" content="Build campaign-ready email templates with live previews and quick exports using the Professional Email Builder by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/professional-email-builder.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Professional Email Builder – Drag & Drop Template Creator">
+  <meta name="twitter:description" content="Design responsive marketing emails quickly with BREN7's Professional Email Builder.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/readability-analyzer.php
+++ b/apps/readability-analyzer.php
@@ -2,24 +2,24 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Readability Analyzer</title>
+  <title>Readability Analyzer – Text Clarity Insights</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Evaluate readability scores, sentence complexity, and content clarity with the BREN7 Readability Analyzer for writers and content teams.">
+  <meta name="keywords" content="readability analyzer, text clarity tool, Flesch reading ease, content analysis, writing assistant">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Readability Analyzer – Text Clarity Insights">
+  <meta property="og:description" content="Measure Flesch scores, grade levels, and keyword density to optimize your copy with the BREN7 Readability Analyzer.">
+  <meta property="og:url" content="https://bren7.com/apps/readability-analyzer.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Readability Analyzer – Text Clarity Insights">
+  <meta name="twitter:description" content="Analyze readability scores and simplify copy with the interactive BREN7 Readability Analyzer.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-content-exporter.php
+++ b/apps/sitemap-content-exporter.php
@@ -169,24 +169,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sitemap Content Exporter</title>
+    <title>Sitemap Content Exporter – Bulk Page Copy Downloader</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Download page content, metadata, and headings from sitemap URLs into shareable reports using the BREN7 Sitemap Content Exporter.">
+  <meta name="keywords" content="sitemap content exporter, bulk copy download, page text extractor, seo content audit, Morweb exporter">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Sitemap Content Exporter – Bulk Page Copy Downloader">
+  <meta property="og:description" content="Capture on-page copy, metadata, and heading structure from sitemap URLs with this exporter by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-content-exporter.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Sitemap Content Exporter – Bulk Page Copy Downloader">
+  <meta name="twitter:description" content="Export on-page copy for every sitemap URL with BREN7's content exporter.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-exporter-advanced.php
+++ b/apps/sitemap-exporter-advanced.php
@@ -155,24 +155,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sitemap to CSV Exporter</title>
+    <title>Sitemap to CSV Exporter – Advanced Insights</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Transform sitemap XML into CSV files enriched with metadata, canonical tags, and analytics-ready fields using BREN7's advanced exporter.">
+  <meta name="keywords" content="advanced sitemap exporter, metadata csv, seo data extraction, url export tool, Morweb sitemap">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Sitemap to CSV Exporter – Advanced Insights">
+  <meta property="og:description" content="Export sitemap URLs with detailed metadata and headings using the advanced sitemap exporter by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-exporter-advanced.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Sitemap to CSV Exporter – Advanced Insights">
+  <meta name="twitter:description" content="Export enhanced sitemap data with the advanced CSV exporter from BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-exporter-basic.php
+++ b/apps/sitemap-exporter-basic.php
@@ -143,24 +143,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sitemap to CSV Exporter</title>
+    <title>Sitemap to CSV Exporter – Quick URL Download</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Download sitemap URLs into a clean CSV for quick audits or sharing with the BREN7 basic sitemap exporter.">
+  <meta name="keywords" content="basic sitemap exporter, sitemap to csv, quick url download, seo url list, Morweb sitemap tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Sitemap to CSV Exporter – Quick URL Download">
+  <meta property="og:description" content="Grab sitemap URLs in seconds with the lightweight CSV exporter by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-exporter-basic.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Sitemap to CSV Exporter – Quick URL Download">
+  <meta name="twitter:description" content="Export sitemap URLs fast with the basic CSV exporter from BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-exporter-enhanced.php
+++ b/apps/sitemap-exporter-enhanced.php
@@ -155,24 +155,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sitemap to CSV Exporter</title>
+    <title>Sitemap to CSV Exporter – Enhanced Metadata Capture</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Convert sitemap XML into enriched CSV files complete with titles, descriptions, and custom fields using the enhanced exporter from BREN7.">
+  <meta name="keywords" content="sitemap to csv exporter, metadata scraper, url inventory tool, seo data export, Morweb sitemap exporter">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Sitemap to CSV Exporter – Enhanced Metadata Capture">
+  <meta property="og:description" content="Download sitemap URLs with titles, descriptions, and change frequencies using the BREN7 enhanced exporter.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-exporter-enhanced.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Sitemap to CSV Exporter – Enhanced Metadata Capture">
+  <meta name="twitter:description" content="Export sitemap data with metadata fields using BREN7's enhanced CSV exporter.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-form-scanner.php
+++ b/apps/sitemap-form-scanner.php
@@ -107,24 +107,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Form Scanner</title>
+    <title>MW Form Scanner – Form Inventory & Action Audit</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Scan sitemap URLs to catalog forms, capture endpoints, and verify submission methods with the BREN7 MW Form Scanner.">
+  <meta name="keywords" content="form scanner, form inventory tool, submission endpoint audit, sitemap form analysis, Morweb form checker">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Form Scanner – Form Inventory & Action Audit">
+  <meta property="og:description" content="Discover forms, actions, and submission types across your sitemap with the MW Form Scanner from BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-form-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Form Scanner – Form Inventory & Action Audit">
+  <meta name="twitter:description" content="Catalog forms and submission endpoints across pages with BREN7's MW Form Scanner.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-image-scanner-lazyload.php
+++ b/apps/sitemap-image-scanner-lazyload.php
@@ -292,24 +292,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Image Scanner</title>
+    <title>MW Image Scanner – Lazy Loading Audit</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Evaluate sitemap images, detect duplicates, and verify lazy loading attributes with the BREN7 MW Image Scanner (Lazy Load Edition).">
+  <meta name="keywords" content="image lazy loading audit, sitemap media scanner, lazyload checker, image performance review, Morweb image tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Image Scanner – Lazy Loading Audit">
+  <meta property="og:description" content="Scan sitemap images to track lazy loading adoption and media coverage with the BREN7 MW Image Scanner.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-image-scanner-lazyload.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Image Scanner – Lazy Loading Audit">
+  <meta name="twitter:description" content="Check lazy loading usage across sitemap images with BREN7's MW Image Scanner.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-image-scanner.php
+++ b/apps/sitemap-image-scanner.php
@@ -229,24 +229,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Image Scanner</title>
+    <title>MW Image Scanner – Sitemap Media Audit</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Crawl a sitemap to audit image usage, detect duplicates, and compile alt text insights with the BREN7 MW Image Scanner.">
+  <meta name="keywords" content="image sitemap scanner, media audit tool, alt text review, duplicate image finder, Morweb image analysis">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Image Scanner – Sitemap Media Audit">
+  <meta property="og:description" content="Analyze sitemap images, uncover duplicates, and review alt text coverage with the BREN7 MW Image Scanner.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-image-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Image Scanner – Sitemap Media Audit">
+  <meta name="twitter:description" content="Scan your sitemap to review image coverage and alt text with the MW Image Scanner by BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-performance-audit-extended.php
+++ b/apps/sitemap-performance-audit-extended.php
@@ -345,24 +345,24 @@ function formatBytes($size, $precision = 2) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Performance Auditor</title>
+    <title>MW Performance Auditor – Extended Lighthouse Review</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Aggregate Lighthouse metrics, Core Web Vitals, and page weights for every sitemap URL with the extended MW Performance Auditor.">
+  <meta name="keywords" content="performance audit tool, lighthouse report aggregator, core web vitals scanner, sitemap performance, Morweb auditor">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Performance Auditor – Extended Lighthouse Review">
+  <meta property="og:description" content="Review performance, accessibility, and SEO metrics for multiple URLs with BREN7's MW Performance Auditor.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-performance-audit-extended.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Performance Auditor – Extended Lighthouse Review">
+  <meta name="twitter:description" content="Compare Lighthouse scores across sitemap URLs with the extended MW Performance Auditor.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-performance-audit.php
+++ b/apps/sitemap-performance-audit.php
@@ -345,24 +345,24 @@ function formatBytes($size, $precision = 2) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Performance Auditor</title>
+    <title>MW Performance Auditor – Sitemap Speed Scores</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Capture Lighthouse performance metrics and core vitals for each sitemap URL with the streamlined MW Performance Auditor from BREN7.">
+  <meta name="keywords" content="lighthouse performance auditor, sitemap speed analysis, web vitals checker, performance dashboard, Morweb tools">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Performance Auditor – Sitemap Speed Scores">
+  <meta property="og:description" content="Compare page speed metrics across sitemap URLs with the MW Performance Auditor by BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-performance-audit.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Performance Auditor – Sitemap Speed Scores">
+  <meta name="twitter:description" content="Review Lighthouse performance scores across your sitemap with this BREN7 tool.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-security-scanner.php
+++ b/apps/sitemap-security-scanner.php
@@ -350,24 +350,24 @@ function getRiskLevel($filename) {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Security Scanner</title>
+    <title>MW Security Scanner – Sitemap Risk Review</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Evaluate sitemap URLs for security signals, mixed content, and vulnerable assets with the BREN7 MW Security Scanner.">
+  <meta name="keywords" content="security sitemap scanner, mixed content checker, vulnerability audit, website security review, Morweb security tool">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Security Scanner – Sitemap Risk Review">
+  <meta property="og:description" content="Scan sitemap endpoints for SSL issues, redirects, and exposed files using the BREN7 MW Security Scanner.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-security-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Security Scanner – Sitemap Risk Review">
+  <meta name="twitter:description" content="Audit sitemap URLs for security gaps with the MW Security Scanner by BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-seo-audit-responsive.php
+++ b/apps/sitemap-seo-audit-responsive.php
@@ -216,24 +216,24 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>SEO Sitemap Audit</title>
+  <title>SEO Sitemap Audit – Responsive Dashboard</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Review sitemap URLs on any device with responsive tables that highlight metadata, headings, and performance issues in the BREN7 SEO Sitemap Audit tool.">
+  <meta name="keywords" content="responsive seo audit, sitemap checker, metadata compliance, mobile seo monitoring, Morweb tools">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="SEO Sitemap Audit – Responsive Dashboard">
+  <meta property="og:description" content="Monitor SEO signals across sitemap URLs with a mobile-friendly dashboard from BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-seo-audit-responsive.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="SEO Sitemap Audit – Responsive Dashboard">
+  <meta name="twitter:description" content="Track SEO checks across devices with the responsive sitemap audit from BREN7.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-seo-audit.php
+++ b/apps/sitemap-seo-audit.php
@@ -216,24 +216,24 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>SEO Sitemap Audit</title>
+  <title>SEO Sitemap Audit – Technical Checks Dashboard</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Run automated SEO checks across sitemap URLs to verify metadata, headings, and performance indicators with the BREN7 SEO Sitemap Audit tool.">
+  <meta name="keywords" content="sitemap seo audit, technical seo scanner, metadata checker, web performance audit, Morweb tools">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="SEO Sitemap Audit – Technical Checks Dashboard">
+  <meta property="og:description" content="Validate titles, descriptions, headings, and core vitals across your sitemap with the BREN7 SEO Sitemap Audit dashboard.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-seo-audit.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="SEO Sitemap Audit – Technical Checks Dashboard">
+  <meta name="twitter:description" content="Scan sitemap URLs for metadata and SEO issues using the BREN7 SEO Sitemap Audit tool.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/sitemap-template-scanner.php
+++ b/apps/sitemap-template-scanner.php
@@ -99,24 +99,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MW Template Scanner</title>
+    <title>MW Template Scanner – Layout Consistency Checker</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Identify page templates, component usage, and CMS layouts across sitemap URLs using the BREN7 MW Template Scanner.">
+  <meta name="keywords" content="template scanner, layout detection tool, cms template audit, sitemap layout analysis, Morweb template scanner">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="MW Template Scanner – Layout Consistency Checker">
+  <meta property="og:description" content="Map templates and shared components across your sitemap with the MW Template Scanner from BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/sitemap-template-scanner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="MW Template Scanner – Layout Consistency Checker">
+  <meta name="twitter:description" content="Discover template usage across sitemap URLs with BREN7's MW Template Scanner.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/website-migration-planner.php
+++ b/apps/website-migration-planner.php
@@ -3,24 +3,24 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Website Migration Planner</title>
+  <title>Website Migration Planner – URL Inventory & Redirect Map</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Organize legacy URLs, assign redirects, and track launch tasks with the BREN7 Website Migration Planner.">
+  <meta name="keywords" content="website migration planner, redirect map, url inventory tool, launch checklist, site relaunch planning">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Website Migration Planner – URL Inventory & Redirect Map">
+  <meta property="og:description" content="Plan site migrations by managing pages, redirects, and QA states inside the BREN7 Website Migration Planner.">
+  <meta property="og:url" content="https://bren7.com/apps/website-migration-planner.php">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
+  <meta name="twitter:title" content="Website Migration Planner – URL Inventory & Redirect Map">
+  <meta name="twitter:description" content="Track redirects and launch tasks with the BREN7 Website Migration Planner.">
   <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
 
   <!-- Favicon -->

--- a/apps/zen-bubbles.php
+++ b/apps/zen-bubbles.php
@@ -3,25 +3,25 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Zen Bubbles</title>
+  <title>Zen Bubbles – Relaxing Bubble Pop Game</title>
   <!-- SEO Meta Tags -->
-  <meta name="description" content="Explore web tools, generators, and utilities from BREN7 to enhance your digital projects.">
-  <meta name="keywords" content="BREN7, web tools, generators, accessibility, SEO, performance, utilities">
+  <meta name="description" content="Unwind with Zen Bubbles, a calming browser game where you pop glowing bubbles beneath a starry sky.">
+  <meta name="keywords" content="Zen Bubbles, relaxing browser game, bubble pop game, stress relief game, calming web game">
   <meta name="author" content="Brent">
   <meta name="robots" content="index, follow">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta property="og:description" content="Browse a collection of creative web tools, games, and utilities built by BREN7.">
-  <meta property="og:url" content="https://bren7.com/">
+  <meta property="og:title" content="Zen Bubbles – Relaxing Bubble Pop Game">
+  <meta property="og:description" content="Float away stress by popping luminous bubbles in this soothing browser experience from BREN7.">
+  <meta property="og:url" content="https://bren7.com/apps/zen-bubbles.php">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://bren7.com/images/favicon.jpg">
+  <meta property="og:image" content="https://bren7.com/images/zen-bubbles-share.png">
 
   <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="BREN7 – Web Projects, Tools & Experiments">
-  <meta name="twitter:description" content="Interactive tools and experiments by BREN7. Explore beat makers, checkers, and more.">
-  <meta name="twitter:image" content="https://bren7.com/images/favicon.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Zen Bubbles – Relaxing Bubble Pop Game">
+  <meta name="twitter:description" content="Pop pastel bubbles and relax under the stars with Zen Bubbles by BREN7.">
+  <meta name="twitter:image" content="https://bren7.com/images/zen-bubbles-share.png">
 
   <!-- Favicon -->
   <link rel="icon" href="https://bren7.com/images/favicon.jpg" type="image/jpeg">
@@ -35,24 +35,6 @@
     gtag('config', 'G-1RGGXKCNB6');
   </script>
 
-
-  <!-- SEO Meta Tags -->
-  <meta name="description" content="Zen Bubbles is a relaxing browser game where you pop floating pastel bubbles under a starry sky. Soothing, simple, and satisfying.">
-  <meta name="keywords" content="Zen Bubbles, relaxing game, bubble pop, calming game, stress relief, simple game, casual browser game">
-  <meta name="author" content="Brent Jlaf">
-
-  <!-- Open Graph Meta Tags (for social sharing) -->
-  <meta property="og:title" content="Zen Bubbles - A Relaxing Bubble Pop Game">
-  <meta property="og:description" content="Unwind with Zen Bubbles — a peaceful game where you pop glowing bubbles beneath a twinkling night sky.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://bren7.com/ZenBubbles/"> <!-- Adjust if hosted elsewhere -->
-  <meta property="og:image" content="https://bren7.com/placeholder.jpg"> <!-- Optional: add a branded placeholder or bubble-themed image -->
-
-  <!-- Twitter Card Meta Tags -->
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Zen Bubbles - A Relaxing Bubble Pop Game">
-  <meta name="twitter:description" content="Unwind and pop some pastel bubbles under the stars. Chill browser game to clear your mind.">
-  <meta name="twitter:image" content="https://bren7.com/placeholder.jpg"> <!-- Optional: same as OG image -->
 
   <!-- Favicon (optional) -->
   <link rel="icon" href="https://bren7.com/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
## Summary
- update application pages with page-specific titles, meta descriptions, keywords, and social cards that describe each tool
- refresh creative experiences with descriptive Open Graph and Twitter metadata for accurate sharing previews
- remove duplicated or generic head tags so every page advertises the correct context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31fbe06a883318bd1ea41df1ac53f