### PR TITLE
Apply BREN7 theme across application pages

### DIFF
--- a/apps/Trakster/trakster-beat-maker.php
+++ b/apps/Trakster/trakster-beat-maker.php
@@ -232,9 +232,28 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
 
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
 <div class="container">
   <!-- Header with Nav -->
   <header>
@@ -733,5 +752,27 @@ $(document).ready(function() {
   });
 });
 </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/accessibility-audit-suite.php
+++ b/apps/accessibility-audit-suite.php
@@ -1400,8 +1400,27 @@ if (!empty($scanResults)) {
             }
         }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <header>
             <h1>🔍 Comprehensive Accessibility Scanner</h1>
@@ -1613,5 +1632,27 @@ if (!empty($scanResults)) {
             </div>
         <?php endif; ?>
     </div>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/accessibility-quick-scan.php
+++ b/apps/accessibility-quick-scan.php
@@ -679,8 +679,27 @@ if (!empty($scanResults)) {
             }
         }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <header>
             <h1>Accessibility Scanner</h1>
@@ -825,5 +844,27 @@ if (!empty($scanResults)) {
             </div>
         <?php endif; ?>
     </div>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/accessible-form-builder.php
+++ b/apps/accessible-form-builder.php
@@ -236,9 +236,28 @@
       margin-right: 5px;
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
 
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container position-relative">
     <h1>Accessible Drag & Drop Form Builder</h1>
 
@@ -1237,5 +1256,27 @@
       });
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/advanced-csv-filter.php
+++ b/apps/advanced-csv-filter.php
@@ -88,8 +88,27 @@
       cursor: pointer;
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <!-- Page Header with About Button -->
     <div class="d-flex justify-content-between align-items-center">
@@ -793,5 +812,27 @@
       $('#filteredExpandModal').modal('show');
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/advanced-image-editor.php
+++ b/apps/advanced-image-editor.php
@@ -311,8 +311,27 @@
       padding-bottom: 10px;
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
 
   <div id="widget-container">
     <!-- Sidebar for Settings -->
@@ -716,5 +735,27 @@
       }
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/animation-effects-gallery.php
+++ b/apps/animation-effects-gallery.php
@@ -76,8 +76,27 @@
     .notification { position: fixed; top: 20px; right: 20px; background-color: #4CAF50; color: white; padding: 15px 20px; border-radius: 8px; display: none; z-index: 1000; }
     @media (max-width: 1024px) { .main-layout { grid-template-columns: 1fr; } .preset-buttons { justify-content: center; } }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>CSS Animation Builder</h1>
@@ -492,5 +511,27 @@
             updateTimeline();
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/bren7-onboarding-experience.php
+++ b/apps/bren7-onboarding-experience.php
@@ -802,8 +802,27 @@
       animation: confetti 2s linear infinite;
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="app">
     <header class="app-header">
       <div class="brand">
@@ -3001,7 +3020,29 @@
               </head>
               <body>
                 <pre>${summary}</pre>
-              </body>
+                    </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
+</body>
             </html>
           `);
           printWindow.document.close();

--- a/apps/card-builder-pro.php
+++ b/apps/card-builder-pro.php
@@ -432,8 +432,27 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <header class="header">
       <h1>Card Builder Pro</h1>
@@ -996,5 +1015,27 @@ ${cardConfig.showButton ? `.${cardConfig.name}__button {
       updateCard();
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/color-palette-generator.php
+++ b/apps/color-palette-generator.php
@@ -209,9 +209,28 @@
       .color-block { min-width: 50px; height: 80px; }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
 
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Color Palette Generator</h1>
@@ -544,5 +563,27 @@
             });
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/css-gradient-generator.php
+++ b/apps/css-gradient-generator.php
@@ -309,9 +309,28 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
 
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header">
       <h1>CSS Gradient Generator</h1>
@@ -646,5 +665,27 @@
       updateDirectionButtons();
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/flexbox-generator-advanced.php
+++ b/apps/flexbox-generator-advanced.php
@@ -140,8 +140,27 @@
       color:#fff;padding:12px 14px;border-radius:10px;display:none;z-index:9999;box-shadow:0 12px 28px rgba(0,0,0,.35)
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header"><h1>Flexbox CSS Generator</h1></div>
 
@@ -643,5 +662,27 @@
       push();
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/flexbox-generator-classic.php
+++ b/apps/flexbox-generator-classic.php
@@ -343,8 +343,27 @@
             }
         }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Flexbox CSS Generator</h1>
@@ -720,5 +739,27 @@
             }
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/heic-to-jpg-converter.php
+++ b/apps/heic-to-jpg-converter.php
@@ -309,8 +309,27 @@
             }
         }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <h1>🖼️ HEIC to JPG</h1>
         <p class="subtitle">Convert your HEIC images to high-quality JPG format instantly</p>
@@ -630,5 +649,27 @@
             new HEICConverter();
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/keyword-density-analyzer.php
+++ b/apps/keyword-density-analyzer.php
@@ -395,8 +395,27 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header">
       <h1><i class="fas fa-search"></i> Keyword Density Analyzer</h1>
@@ -564,5 +583,27 @@
       }
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/lorem-ipsum-scanner.php
+++ b/apps/lorem-ipsum-scanner.php
@@ -523,8 +523,27 @@ tbody tr:nth-child(even) {
 }
 
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-italic"></i> Lorem Ipsum Checker</h1>
@@ -632,5 +651,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/meta-tag-generator.php
+++ b/apps/meta-tag-generator.php
@@ -40,8 +40,27 @@
     body { padding: 2rem; }
     textarea { font-family: monospace; }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
 
   <div class='container'>
     <h1 class='mb-4 text-center'>Meta Tag Generator from URL</h1>
@@ -162,6 +181,28 @@
       $('#output').val(metaTags);
     });
   </script>
+
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
 
 </body>
 </html>

--- a/apps/missing-alt-scanner.php
+++ b/apps/missing-alt-scanner.php
@@ -619,8 +619,27 @@ class AltTagScanner {
             }
         }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>🔍 Website Alt Tag Scanner</h1>
@@ -899,5 +918,27 @@ class AltTagScanner {
             }
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/mobile-friendliness-checker.php
+++ b/apps/mobile-friendliness-checker.php
@@ -866,8 +866,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-mobile-alt"></i> Mobile Friendliness Checker</h1>
@@ -1146,5 +1165,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/professional-email-builder.php
+++ b/apps/professional-email-builder.php
@@ -569,8 +569,27 @@
       to { transform: rotate(360deg); }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <!-- Loading Overlay -->
   <div class="loading-overlay" id="loadingOverlay">
     <div class="loading-spinner"></div>
@@ -1708,7 +1727,29 @@
             ${headerHtml}
             <div class="email-body">${emailHtml}</div>
             ${footerCombined}
-          </body>
+                </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
+</body>
         </html>
       `;
 

--- a/apps/readability-analyzer.php
+++ b/apps/readability-analyzer.php
@@ -401,8 +401,27 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header">
       <h1><i class="fas fa-align-left"></i> Readability Analyzer</h1>
@@ -625,5 +644,27 @@
       return m ? m.length : 1;
     }
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-content-exporter.php
+++ b/apps/sitemap-content-exporter.php
@@ -142,7 +142,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header('Content-Type: application/msword; charset=UTF-8');
             header('Content-Disposition: attachment; filename="' . $filename . '"');
 
-            echo "<html><head><meta charset='utf-8'></head><body>";
+            echo <<<'HTML'
+<html>
+<head><meta charset='utf-8'>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+HTML;
             foreach ($urls as $url) {
                 $data = fetchPageData($url);
                 if (!$data) continue;
@@ -158,7 +180,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 flush();
                 sleep(1);
             }
-            echo "</body></html>";
+            echo <<<'HTML'
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
+</body></html>
+HTML;
             exit;
         }
     }

--- a/apps/sitemap-exporter-advanced.php
+++ b/apps/sitemap-exporter-advanced.php
@@ -515,8 +515,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Sitemap Exporter</h1>
@@ -673,5 +692,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-exporter-basic.php
+++ b/apps/sitemap-exporter-basic.php
@@ -390,8 +390,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         display: block;
     }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Sitemap Exporter</h1>
@@ -463,5 +482,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-exporter-enhanced.php
+++ b/apps/sitemap-exporter-enhanced.php
@@ -515,8 +515,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Sitemap Exporter</h1>
@@ -673,5 +692,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-form-scanner.php
+++ b/apps/sitemap-form-scanner.php
@@ -489,8 +489,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-code"></i> MW Form Scanner</h1>
@@ -643,5 +662,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-image-scanner-lazyload.php
+++ b/apps/sitemap-image-scanner-lazyload.php
@@ -770,8 +770,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-images"></i> MW Image Scanner</h1>
@@ -1075,5 +1094,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-image-scanner.php
+++ b/apps/sitemap-image-scanner.php
@@ -697,8 +697,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-images"></i> MW Image Scanner</h1>
@@ -932,5 +951,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-performance-audit-extended.php
+++ b/apps/sitemap-performance-audit-extended.php
@@ -834,8 +834,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-tachometer-alt"></i> MW Performance Auditor</h1>
@@ -1156,5 +1175,27 @@ tbody tr:nth-child(even) {
         document.body.removeChild(link);
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-performance-audit.php
+++ b/apps/sitemap-performance-audit.php
@@ -816,8 +816,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-tachometer-alt"></i> MW Performance Auditor</h1>
@@ -1037,5 +1056,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-security-scanner.php
+++ b/apps/sitemap-security-scanner.php
@@ -857,8 +857,27 @@ tbody tr:nth-child(even) {
     }
 }
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-shield-alt"></i> MW Security Scanner</h1>
@@ -1148,5 +1167,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/sitemap-seo-audit-responsive.php
+++ b/apps/sitemap-seo-audit-responsive.php
@@ -591,8 +591,27 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header">
       <h1><i class="fas fa-sitemap"></i> SEO Sitemap Audit</h1>
@@ -713,6 +732,28 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       $('#scan-btn').prop('disabled', false).html('<i class="fas fa-play"></i> Run Audit');
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 
 </html>

--- a/apps/sitemap-seo-audit.php
+++ b/apps/sitemap-seo-audit.php
@@ -591,8 +591,27 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="container">
     <div class="header">
       <h1><i class="fas fa-sitemap"></i> SEO Sitemap Audit</h1>
@@ -713,6 +732,28 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
       $('#scan-btn').prop('disabled', false).html('<i class="fas fa-play"></i> Run Audit');
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 
 </html>

--- a/apps/sitemap-template-scanner.php
+++ b/apps/sitemap-template-scanner.php
@@ -533,8 +533,27 @@ tbody tr:nth-child(even) {
 }
 
     </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1><i class="fas fa-code"></i> MW Template Scanner</h1>
@@ -700,5 +719,27 @@ tbody tr:nth-child(even) {
         });
     });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/tint-shade-generator.php
+++ b/apps/tint-shade-generator.php
@@ -259,9 +259,28 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
 
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
     <div class="container">
         <div class="header">
             <h1>Tint &amp; Shade Generator</h1>
@@ -481,5 +500,27 @@
             });
         });
     </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/website-migration-planner.php
+++ b/apps/website-migration-planner.php
@@ -104,8 +104,27 @@
     .link{color:var(--accent); text-decoration:none}
     .drag{cursor:grab}
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <div class="app">
     <header>
       <div style="display:flex; align-items:center; gap:10px">
@@ -535,5 +554,27 @@ https://example.com/about
     // Initial render
     render();
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/apps/zen-bubbles.php
+++ b/apps/zen-bubbles.php
@@ -117,8 +117,27 @@
       100% { transform: translateY(110vh); }
     }
   </style>
+  <link rel="stylesheet" href="/css/style.css">
+  <link rel="stylesheet" href="/css/app-theme.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
+
 </head>
-<body>
+<body class="app-page">
+  <div class="grid-background"></div>
+  <div class="main-wrapper app-wrapper">
+    <header class="app-header">
+      <div class="header-content">
+        <div class="logo-wrapper">
+          <div class="logo">BREN<span class="accent">7</span></div>
+          <div class="logo-underline"></div>
+        </div>
+        <p class="tagline">Web Tools & Experiments</p>
+      </div>
+    </header>
+    <main class="app-main">
+      <div class="app-content">
+
   <!-- Container for the twinkling stars -->
   <div id="stars"></div>
   <!-- Score display -->
@@ -205,5 +224,27 @@
       gameArea.style.height = window.innerHeight + 'px';
     });
   </script>
+      </div>
+    </main>
+    <footer class="app-footer">
+      <div class="footer-content">
+        <div class="social-links">
+          <a href="https://discordapp.com/users/Bliss#6318" class="social-link" target="_blank" rel="noopener" aria-label="Discord">
+            <i class="fab fa-discord"></i>
+            <span>Discord</span>
+          </a>
+          <a href="https://github.com/brentjlaf" class="social-link" target="_blank" rel="noopener" aria-label="GitHub">
+            <i class="fab fa-github"></i>
+            <span>GitHub</span>
+          </a>
+        </div>
+        <div class="footer-info">
+          <p>&copy; <span id="current-year"></span> BREN7. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  </div>
+  <script>document.getElementById('current-year').textContent = new Date().getFullYear();</script>
+
 </body>
 </html>

--- a/css/app-theme.css
+++ b/css/app-theme.css
@@ -1,0 +1,291 @@
+/* Shared application theme for BREN7 tools */
+
+body.app-page {
+  font-family: var(--font-secondary, 'Raleway', sans-serif);
+  background: var(--color-bg, #000);
+  color: var(--color-light-text, #f5f5f5);
+  min-height: 100vh;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body.app-page a {
+  color: var(--color-accent, #5cccf4);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+body.app-page a:hover,
+body.app-page a:focus {
+  color: var(--color-accent-hover, #33b0da);
+  opacity: 0.85;
+}
+
+.app-wrapper {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 48px 20px 32px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+  text-align: center;
+}
+
+.app-main {
+  flex: 1;
+  padding: 60px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.app-content {
+  width: 100%;
+  max-width: min(1400px, 95vw);
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: 24px;
+  padding: 48px 40px;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(8px);
+}
+
+.app-content > *:first-child {
+  margin-top: 0;
+}
+
+.app-content > *:last-child {
+  margin-bottom: 0;
+}
+
+.app-content h1,
+.app-content h2,
+.app-content h3,
+.app-content h4,
+.app-content h5,
+.app-content h6 {
+  font-family: var(--font-primary, 'Oswald', sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 24px;
+}
+
+.app-content h1 {
+  font-size: clamp(2.5rem, 3vw + 1rem, 3.5rem);
+}
+
+.app-content h2 {
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.5rem);
+}
+
+.app-content p,
+.app-content li,
+.app-content label,
+.app-content span {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.app-content ul,
+.app-content ol {
+  margin: 0 0 24px 24px;
+  padding-left: 24px;
+}
+
+.app-content code,
+.app-content pre {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+
+body.app-page button,
+body.app-page input,
+body.app-page select,
+body.app-page textarea {
+  background: rgba(10, 10, 10, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+  padding: 12px 16px;
+  border-radius: 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+body.app-page input:focus,
+body.app-page select:focus,
+body.app-page textarea:focus {
+  outline: none;
+  border-color: var(--color-accent, #5cccf4);
+  box-shadow: 0 0 0 3px rgba(92, 204, 244, 0.25);
+}
+
+body.app-page button,
+body.app-page .btn,
+body.app-page button.btn-primary,
+body.app-page button.btn-secondary,
+body.app-page a.btn {
+  background: linear-gradient(135deg, var(--color-accent, #5cccf4), #2d9ac0);
+  color: #000;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(92, 204, 244, 0.25);
+}
+
+body.app-page button:hover,
+body.app-page .btn:hover,
+body.app-page button.btn-primary:hover,
+body.app-page button.btn-secondary:hover,
+body.app-page a.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(92, 204, 244, 0.35);
+  color: #000;
+}
+
+body.app-page button:disabled,
+body.app-page .btn:disabled,
+body.app-page button.btn-primary:disabled,
+body.app-page button.btn-secondary:disabled,
+body.app-page a.btn.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+body.app-page table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+body.app-page table th,
+body.app-page table td {
+  padding: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+body.app-page table thead th {
+  font-family: var(--font-primary, 'Oswald', sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+body.app-page table tbody tr:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+body.app-page .container,
+body.app-page .card,
+body.app-page .card-body,
+body.app-page .card-header,
+body.app-page .panel,
+body.app-page .panel-body,
+body.app-page .tool-section,
+body.app-page .tool-card,
+body.app-page .section-block,
+body.app-page .result-card,
+body.app-page .stat-card,
+body.app-page .module,
+body.app-page .content-section,
+body.app-page .results,
+body.app-page .results-card,
+body.app-page .results-wrapper,
+body.app-page .info-box,
+body.app-page .status-card,
+body.app-page .insight-card,
+body.app-page .detail-card,
+body.app-page .summary-card,
+body.app-page .data-card,
+body.app-page .form-card,
+body.app-page .tab-content,
+body.app-page .accordion-item,
+body.app-page .accordion-body {
+  background: rgba(10, 10, 10, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+body.app-page .card-header,
+body.app-page .panel-heading,
+body.app-page .accordion-header {
+  background: rgba(255, 255, 255, 0.05);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+body.app-page .badge,
+body.app-page .label,
+body.app-page .tag,
+body.app-page .status {
+  background: rgba(92, 204, 244, 0.18);
+  color: rgba(92, 204, 244, 0.95);
+  border-radius: 999px;
+  padding: 6px 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.app-footer {
+  padding: 32px 20px 48px;
+  border-top: 1px solid var(--color-border, rgba(255, 255, 255, 0.1));
+}
+
+.app-footer .footer-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  align-items: center;
+}
+
+.app-footer .social-links {
+  display: flex;
+  gap: 24px;
+}
+
+.app-footer .social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: rgba(255, 255, 255, 0.8);
+  text-decoration: none;
+  font-family: var(--font-secondary, 'Raleway', sans-serif);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.app-footer .social-link i {
+  font-size: 1.2rem;
+}
+
+.app-footer .footer-info p {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .app-content {
+    padding: 32px 24px;
+  }
+
+  .app-footer .social-links {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap every application page with the BREN7 header/footer shell and shared layout elements so the tools match the landing page aesthetic
- add css/app-theme.css to provide global typography, form, and card styling overrides that mirror index.php and style.css
- update sitemap-content-exporter.php to emit the themed markup when generating downloadable documents

## Testing
- find apps -name '*.php' -print0 | while IFS= read -r -d '' file; do php -l "$file" >/tmp/php_lint.log || { cat /tmp/php_lint.log; exit 1; }; done

------
https://chatgpt.com/codex/tasks/task_e_68e3228041108331a4be85e1255a428f