### PR TITLE
Remove white background styling from headers

### DIFF
--- a/apps/keyword-density-analyzer.php
+++ b/apps/keyword-density-analyzer.php
@@ -90,11 +90,10 @@
     .header {
       text-align: center;
       margin-bottom: 2rem;
-      background: var(--white);
       padding: 2rem;
       border-radius: 12px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-      border: 1px solid var(--medium-gray);
+      border: 1px solid var(--dark-gray);
     }
     .header h1 {
       font-size: 2.5rem;

--- a/apps/lorem-ipsum-scanner.php
+++ b/apps/lorem-ipsum-scanner.php
@@ -210,11 +210,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/mobile-friendliness-checker.php
+++ b/apps/mobile-friendliness-checker.php
@@ -500,11 +500,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/readability-analyzer.php
+++ b/apps/readability-analyzer.php
@@ -89,11 +89,10 @@
     .header {
       text-align: center;
       margin-bottom: 2rem;
-      background: var(--white);
       padding: 2rem;
       border-radius: 12px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-      border: 1px solid var(--medium-gray);
+      border: 1px solid var(--dark-gray);
     }
     .header h1 {
       font-size: 2.5rem;

--- a/apps/sitemap-form-scanner.php
+++ b/apps/sitemap-form-scanner.php
@@ -201,11 +201,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-image-scanner-lazyload.php
+++ b/apps/sitemap-image-scanner-lazyload.php
@@ -413,11 +413,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-image-scanner.php
+++ b/apps/sitemap-image-scanner.php
@@ -350,11 +350,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-performance-audit-extended.php
+++ b/apps/sitemap-performance-audit-extended.php
@@ -466,11 +466,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-performance-audit.php
+++ b/apps/sitemap-performance-audit.php
@@ -466,11 +466,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-security-scanner.php
+++ b/apps/sitemap-security-scanner.php
@@ -452,11 +452,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;

--- a/apps/sitemap-seo-audit-responsive.php
+++ b/apps/sitemap-seo-audit-responsive.php
@@ -302,11 +302,10 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
     .header {
       text-align: center;
       margin-bottom: 3rem;
-      background: var(--white);
       padding: 2.5rem;
       border-radius: 16px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-      border: 1px solid var(--medium-gray);
+      border: 1px solid var(--dark-gray);
     }
     .header h1 {
       font-size: 2.5rem;

--- a/apps/sitemap-seo-audit.php
+++ b/apps/sitemap-seo-audit.php
@@ -302,11 +302,10 @@ if (!empty($_GET['export']) && $_GET['export'] == '1' && !empty($all_results)) {
     .header {
       text-align: center;
       margin-bottom: 3rem;
-      background: var(--white);
       padding: 2.5rem;
       border-radius: 16px;
       box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-      border: 1px solid var(--medium-gray);
+      border: 1px solid var(--dark-gray);
     }
     .header h1 {
       font-size: 2.5rem;

--- a/apps/sitemap-template-scanner.php
+++ b/apps/sitemap-template-scanner.php
@@ -220,11 +220,10 @@ body {
 .header {
     text-align: center;
     margin-bottom: 3rem;
-    background: var(--white);
     padding: 2.5rem;
     border-radius: 16px;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-    border: 1px solid var(--medium-gray);
+    border: 1px solid var(--dark-gray);
 }
 .header h1 {
     font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- remove the white background color from all `.header` blocks across the sitemap utilities
- update each `.header` border to use `var(--dark-gray)` for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5343cdf248331b6b12876c3fe5755